### PR TITLE
Don't hard depend on dalli

### DIFF
--- a/peek-dalli.gemspec
+++ b/peek-dalli.gemspec
@@ -18,6 +18,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'peek'
-  gem.add_dependency 'dalli'
   gem.add_dependency 'atomic', '>= 1.0.0'
 end


### PR DESCRIPTION
Other `ActiveSupport::Cache::Store` stores not powered by dalli still emit the same `ActiveSupport::Notifications`, like the one that comes with libmemcached. Removing this hard dependency is useful so we don't need to include the dalli gem to instrument a different store.