### PR TITLE
display long durations in seconds

### DIFF
--- a/lib/peek/views/dalli.rb
+++ b/lib/peek/views/dalli.rb
@@ -17,7 +17,7 @@ module Peek
       def formatted_duration
         ms = @duration.value * 1000
         if ms >= 1000
-          "%.2fms" % ms
+          "%.2fs" % (ms / 1e3)
         else
           "%.0fms" % ms
         end


### PR DESCRIPTION
The duration display for particularly long durations seemed to be incorrect. I switched it to show time in seconds out to two decimal places which I think was the original intent.

Previously:

```
> "%.2fms" % 1500
=> "1500.00ms"
```

Now:

```
> "%.2fs" % (1500 / 1e3)
=> "1.50s"
```