### PR TITLE
Upgrade to use `concurrent-ruby` instead of `atomic`

### DIFF
--- a/lib/peek/views/dalli.rb
+++ b/lib/peek/views/dalli.rb
@@ -1,16 +1,16 @@
-require 'atomic'
+require 'concurrent/atomics'
 
 module Peek
   module Views
     class Dalli < View
       def initialize(options = {})
-        @duration = Atomic.new(0)
-        @calls = Atomic.new(0)
+        @duration = Concurrent::Atomic.new(0)
+        @calls    = Concurrent::Atomic.new(0)
 
-        @reads = Atomic.new(0)
-        @misses = Atomic.new(0)
-        @writes = Atomic.new(0)
-        @others = Atomic.new(0)
+        @reads  = Concurrent::Atomic.new(0)
+        @misses = Concurrent::Atomic.new(0)
+        @writes = Concurrent::Atomic.new(0)
+        @others = Concurrent::Atomic.new(0)
 
         setup_subscribers
       end
@@ -26,7 +26,7 @@ module Peek
 
       def context
         {
-          :reads => @reads.value,
+          :reads  => @reads.value,
           :misses => @misses.value,
           :writes => @writes.value,
           :others => @others.value,
@@ -36,7 +36,7 @@ module Peek
       def results
         {
           :duration => formatted_duration,
-          :calls => @calls.value,
+          :calls    => @calls.value,
         }
       end
 
@@ -46,9 +46,9 @@ module Peek
         # Reset each counter when a new request starts
         before_request do
           @duration.value = 0
-          @calls.value = 0
+          @calls.value    = 0
 
-          @reads.value = 0
+          @reads.value  = 0
           @misses.value = 0
           @writes.value = 0
           @others.value = 0

--- a/peek-dalli.gemspec
+++ b/peek-dalli.gemspec
@@ -19,5 +19,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'peek'
   gem.add_dependency 'dalli'
-  gem.add_dependency 'atomic', '>= 1.0.0'
+  gem.add_dependency 'concurrent-ruby'
+  gem.add_dependency 'concurrent-ruby-ext'
 end


### PR DESCRIPTION
atomic has been [deprecated](https://github.com/ruby-concurrency/atomic#deprecated) and superseded by [concurrent-ruby](https://github.com/ruby-concurrency/concurrent-ruby). This bumps
the dependencies to use concurrent ruby and do away with the atomic gem.

@dewski I was unable to see how to run any tests but if you let me know cut a
pre-release I'd be happy to litmus test it for you.