### PR TITLE
`Atomic` -> `AtomicReference`

### DIFF
--- a/lib/peek/views/dalli.rb
+++ b/lib/peek/views/dalli.rb
@@ -4,13 +4,13 @@ module Peek
   module Views
     class Dalli < View
       def initialize(options = {})
-        @duration = Concurrent::Atomic.new(0)
-        @calls    = Concurrent::Atomic.new(0)
+        @duration = Concurrent::AtomicReference.new(0)
+        @calls    = Concurrent::AtomicReference.new(0)
 
-        @reads  = Concurrent::Atomic.new(0)
-        @misses = Concurrent::Atomic.new(0)
-        @writes = Concurrent::Atomic.new(0)
-        @others = Concurrent::Atomic.new(0)
+        @reads  = Concurrent::AtomicReference.new(0)
+        @misses = Concurrent::AtomicReference.new(0)
+        @writes = Concurrent::AtomicReference.new(0)
+        @others = Concurrent::AtomicReference.new(0)
 
         setup_subscribers
       end


### PR DESCRIPTION
In #7 I had `Concurrent::Atomic` however for this to boot and be used correctly
it actually needs `Concurrent::AtomicReference`. On another note, I don't leverage 
any of the advanced uses of `concurrent-ruby` so it would be good to get someone 
who does to confirm this still works for them too.

Apologies @dewski :cry: